### PR TITLE
feat: add a preset `file`, which parameterize fileMatch

### DIFF
--- a/file.json
+++ b/file.json
@@ -1,0 +1,16 @@
+{
+  "regexManagers": [
+    {
+      "fileMatch": ["{{arg0}}"],
+      "matchStrings": [
+        " +(version|ref): (?<currentValue>[^'\"\\n]*) +# renovate: depName=(?<depName>[^\\n]+)",
+        " +(version|ref): \"(?<currentValue>[^'\"\\n]*)\" +# renovate: depName=(?<depName>[^\\n]+)",
+        " +(version|ref): '(?<currentValue>[^'\"\\n]*)' +# renovate: depName=(?<depName>[^\\n]+)",
+        " +name: (?<depName>[^'\"\\n]*)@(?<currentValue>[^'\"\\n]+)",
+        " +name: \"(?<depName>[^'\\n]*)@(?<currentValue>[^'\"\\n]+)\"",
+        " +name: '(?<depName>[^\"\\n]*)@(?<currentValue>[^'\"\\n]+)'"
+      ],
+      "datasourceTemplate": "github-releases"
+    }
+  ]
+}


### PR DESCRIPTION
It works well.

* https://github.com/suzuki-shunsuke/test-renovate/pull/108
* https://github.com/suzuki-shunsuke/test-renovate/pull/109
* https://github.com/suzuki-shunsuke/test-renovate/blob/4859b8cf58f0179746d383948aa08c32f3f3e501/file.json
* https://github.com/suzuki-shunsuke/test-renovate/blob/4859b8cf58f0179746d383948aa08c32f3f3e501/renovate.json#L4

e.g.

```json
  "extends": [
    "config:base",
    "github>suzuki-shunsuke/aqua-renovate-config:file(aqua/.*\\.ya?ml)"
  ]
```